### PR TITLE
Hot Fix: Query device name when loading latest config

### DIFF
--- a/ae/ae-ios/Device/FXBDevice/DeviceConnectionCellView.swift
+++ b/ae/ae-ios/Device/FXBDevice/DeviceConnectionCellView.swift
@@ -41,6 +41,20 @@ struct DeviceConnectionCellView: View {
                     Toggle("Auto Connect", isOn: $vm.shouldAutoConnect)
                         .labelsHidden()
                 }
+                
+                Divider()
+                
+                HStack {
+                    Spacer()
+                    NavigationLink(destination: {
+                        DataStreamsView(deviceSpec: vm.device.spec, deviceName: vm.device.deviceName)
+                            .navigationBarTitleDisplayMode(.inline)
+                            .navigationTitle("\(vm.device.deviceName)")
+                    }, label: {
+                        Text("Manage Data Streams").buttonStyle(.bordered)
+                    })
+                }
+                
             case .connecting:
                 KeyValueView(key: "Status", value: "Connecting")
             case .initializing:

--- a/ae/ae-ios/Device/FXBDevice/FXBDeviceSpecConnectionView.swift
+++ b/ae/ae-ios/Device/FXBDevice/FXBDeviceSpecConnectionView.swift
@@ -27,29 +27,33 @@ struct FXBDeviceSpecConnectionView: View {
             Spacer(minLength: 8.0)
             Text(spec.description)
                 .font(.body)
+            
             Divider()
+            
+            switch conn.fxbFoundDevices {
+            case let ds where ds.count == 1: Text("\(ds.count) device found").font(.body)
+            case let ds where ds.count > 1: Text("\(ds.count) devices found").font(.body)
+            default: Text("No devices found").font(.body)
+            }
+            switch conn.fxbConnectedDevices {
+            case let ds where ds.count == 1: Text("\(ds.count) device connected").font(.body)
+            case let ds where ds.count > 1: Text("\(ds.count) devices connected").font(.body)
+            default: Text("No devices connected").font(.body)
+            }
+            
+            Spacer()
+            
             HStack {
-                VStack(alignment: .leading) {
-                    switch conn.fxbFoundDevices {
-                    case let ds where ds.count == 1: Text("\(ds.count) device found").font(.body)
-                    case let ds where ds.count > 1: Text("\(ds.count) devices found").font(.body)
-                    default: Text("No devices found").font(.body)
-                    }
-                    switch conn.fxbConnectedDevices {
-                    case let ds where ds.count == 1: Text("\(ds.count) device connected").font(.body)
-                    case let ds where ds.count > 1: Text("\(ds.count) devices connected").font(.body)
-                    default: Text("No devices connected").font(.body)
-                    }
-                }
                 Spacer()
                 NavigationLink(destination: {
                     SelectFXBDeviceConnectionView(deviceSpec: spec)
                         .navigationBarTitleDisplayMode(.inline)
                         .navigationTitle("\(spec.name) Devices")
                 }, label: {
-                    Text("Manage").buttonStyle(.bordered)
+                    Text("View Devices").buttonStyle(.bordered)
                 })
             }
+            
         }.padding()
     }
 }

--- a/ae/ae-ios/Device/FXBDevice/SelectFXBDeviceConnectionView.swift
+++ b/ae/ae-ios/Device/FXBDevice/SelectFXBDeviceConnectionView.swift
@@ -16,8 +16,14 @@ struct SelectFXBDeviceConnectionView: View {
     @StateObject private var conn = fxb.conn
     
     var body: some View {
-        List(fxb.conn.fxbConnectedDevices + fxb.conn.fxbFoundDevices) {
-            DeviceConnectionCellView(vm: FXBDeviceViewModel(with: $0))
+        VStack(alignment: .leading) {
+            ForEach((fxb.conn.fxbConnectedDevices + fxb.conn.fxbFoundDevices)
+                .sorted(by: { $0.deviceName < $1.deviceName })) {
+                
+                    DeviceConnectionCellView(vm: FXBDeviceViewModel(with: $0))
+                    .modifier(Card())
+            }
+            Spacer()
         }
     }
 }

--- a/ae/ae-ios/MainTabView.swift
+++ b/ae/ae-ios/MainTabView.swift
@@ -13,15 +13,9 @@ struct MainTabView: View {
     var body: some View {
         TabView {
             DevicesView(vm: FlexiBLESpecViewModel())
-//            AEThingsView(vm: AEViewModel(with: "exthub.json"))
                 .tabItem{
                     Image(systemName: "memorychip")
                     Text("Devices")
-                }
-            DeviceDataView()
-                .tabItem {
-                    Image(systemName: "externaldrive.fill.badge.timemachine")
-                    Text("Data")
                 }
             ExperimentsView()
                 .tabItem {


### PR DESCRIPTION
closes #28, #18, #23

* Remove the data tab, data steam management is now reachable by selecting a device in the devices tab.
  * this resolves issues when switching devices on the data tab and viewing disconnected devices.
* Reloves a bug when loading most recent configurations when more than one device types has been connected.